### PR TITLE
scripts for cloning from personal forks and npm installing; added setup on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a launch control program capable of launching our stack.
 
 ## Setup
 
-1. Begin inisde the local directory for this (kaskade) repo
+1. Begin inside the local directory for this (kaskade) repo
 1. Prepare to clone all available services, as identified in [`config.json`](config.json)
 
   ```sh
@@ -21,6 +21,5 @@ This is a launch control program capable of launching our stack.
 1. NPM Install all service dependencies
 
   ```sh
-  $ chmod +x npmi.sh
   $ ./npmi.sh
   ```

--- a/README.md
+++ b/README.md
@@ -12,14 +12,32 @@ This is a launch control program capable of launching our stack.
   $ npm install
   ```
 
-1. Clone all available services (from your personal forks). The various service repos are cloned into this (kaskade) repo's parent directory (they are not submodules at this time)
+1. Clone all available services (from your personal forks). The various service repos are cloned **into this (kaskade) repo's parent directory** (they are not submodules at this time)
 
   ```sh
   $ node klone <your github username>
   ```
 
-1. NPM Install all service dependencies
+1. Install dependencies and build services
 
   ```sh
-  $ ./npmi.sh
+  $ ./build.sh
   ```
+
+1. Modify the [`run`](./run) file to include a check on your `$USER` name and export `KASKADE_FILTER` with a comma delimited list of services to **exclude** running when kaskade is started from `./run`
+
+## Running
+
+```sh
+# To Test The System
+$ ./kaskade --test
+
+# To Run All Services With Debug
+$ ./kaskade --debug
+
+# To Run All Services Silently
+$ ./kaskade
+
+# To Run With Filters, Based On $USER
+$ ./run
+```

--- a/README.md
+++ b/README.md
@@ -2,3 +2,25 @@ kaskade
 =======
 
 This is a launch control program capable of launching our stack.
+
+## Setup
+
+1. Begin inisde the local directory for this (kaskade) repo
+1. Prepare to clone all available services, as identified in [`config.json`](config.json)
+
+  ```sh
+  $ npm install
+  ```
+
+1. Clone all available services (from your personal forks). The various service repos are cloned into this (kaskade) repo's parent directory (they are not submodules at this time)
+
+  ```sh
+  $ node klone <your github username>
+  ```
+
+1. NPM Install all service dependencies
+
+  ```sh
+  $ chmod +x npmi.sh
+  $ ./npmi.sh
+  ```

--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,26 @@
 #!/bin/bash
 
-for dir in */; do
-  if [ -f "$dir/package.json" ]; then
-    echo "NPM installing $dir."
-    cd $dir
-    npm install
-    cd ..
-  elif [ -f "$dir/pom.xml" ]; then
-    echo "Maven build on $dir."
-    cd $dir
-    mvn
-    cd ..
-  fi
-done
+for d in $(find .. -name 'pom.xml' | grep -v 'node_modules' | sed 's/\/pom\.xml//g'); do
+cd $d
+echo "Maven build on $d";
+mvn
+if [ -f install_esb_jar_to_maven.sh ]; then
+  cat <<EOF
+
+_____________________________
+
+ INSTALLING ESB JAR TO MAVEN
+_____________________________
+
+
+EOF
+
+  ./install_esb_jar_to_maven.sh
+fi
+cd -; done
+
+for d in $(find .. -name 'package.json' | grep -v 'node_modules' | sed 's/\/package\.json//g'); do
+cd $d
+echo "NPM Installing $d";
+npm install
+cd -; done

--- a/klone.js
+++ b/klone.js
@@ -18,6 +18,11 @@ if (!!process.argv[2]) {
 
 var config = JSON.parse(fs.readFileSync('config.json', 'utf8'));
 
+// start with adding the upstream for this repo
+exec('git remote add upstream ' + gitUpstreamUrl + '/kaskade', function(code, output) {
+  // carry on
+});
+
 for (service in config) {
   repo = config[service].dir.replace(/^..\//, '')
     .replace(/\/.*/, '');

--- a/klone.js
+++ b/klone.js
@@ -1,9 +1,12 @@
 require('shelljs/global');
 var fs = require('fs');
 var gitUrl = 'git@github.com:';
+var gitUpstreamUrl = gitUrl + 'helpdotcom';
 var username;
 var service;
+var upstreamRepo;
 var repo;
+var repoUrl;
 var repoCache = [];
 
 if (!!process.argv[2]) {
@@ -24,9 +27,10 @@ for (service in config) {
   }
   repoCache.push(repo);
 
-  repo = gitUrl + '/' + repo;
+  upstreamRepo = gitUpstreamUrl + '/' + repo;
+  repoUrl = gitUrl + '/' + repo;
 
-  exec('cd .. && git clone ' + repo, function(code, output) {
+  exec('cd .. && git clone ' + repoUrl + ' && cd ' + repo + ' && git remote add upstream ' + upstreamRepo + ' && git remote -v', function(code, output) {
     // carry on
   });
 }

--- a/klone.js
+++ b/klone.js
@@ -1,0 +1,32 @@
+require('shelljs/global');
+var fs = require('fs');
+var gitUrl = 'git@github.com:';
+var username;
+var service;
+var repo;
+var repoCache = [];
+
+if (!!process.argv[2]) {
+  username = process.argv[2];
+  gitUrl += username;
+} else {
+  throw new Error('your GitHub username is required as an argument');
+}
+
+var config = JSON.parse(fs.readFileSync('config.json', 'utf8'));
+
+for (service in config) {
+  repo = config[service].dir.replace(/^..\//, '')
+    .replace(/\/.*/, '');
+
+  if (repoCache.indexOf(repo) >= 0) {
+    continue;
+  }
+  repoCache.push(repo);
+
+  repo = gitUrl + '/' + repo;
+
+  exec('cd .. && git clone ' + repo, function(code, output) {
+    // carry on
+  });
+}

--- a/npmi.sh
+++ b/npmi.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 for d in $(find .. -name 'package.json' | grep -v 'node_modules' | sed 's/\/package\.json//g'); do
 cd $d
 echo "NPM Installing $d ...";

--- a/npmi.sh
+++ b/npmi.sh
@@ -1,0 +1,5 @@
+for d in $(find .. -name 'package.json' | grep -v 'node_modules' | sed 's/\/package\.json//g'); do
+cd $d
+echo "NPM Installing $d ...";
+npm install
+cd -; done

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "kaskade",
+  "description": "runs the world",
+  "dependencies": {
+    "shelljs": "^0.3.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/helpdotcom/kaskade"
+  }
+}


### PR DESCRIPTION
You'll notice:
1. klone.js evals the config.json to determine what needs to be cloned.
2. It clones from your personal fork, rather than the org/master
3. README content